### PR TITLE
Fix tag-error for ICP-versions > 3.x 

### DIFF
--- a/scripts/boot-master/functions.sh
+++ b/scripts/boot-master/functions.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 DefaultOrg="ibmcom"
 DefaultRepo="icp-inception"
+DefaultRepoAmd64="icp-inception-amd64"
 
 # Populates globals $org $repo $tag
 function parse_icpversion() {
@@ -30,10 +31,15 @@ function parse_icpversion() {
   fi
 
   # Determine repository and tag
+  # Determine if 2.x or 3.x
   if [[ $1 =~ .*:.* ]]
   then
     repo=$(echo ${1##*/} | cut -d: -f1)
     tag=$(echo ${1##*/} | cut -d/ -f2 | cut -d: -f2)
+  elif [[ ${1:0:1} == "3" ]]
+  then
+    repo=$DefaultRepoAmd64
+    tag=$1
   else
     repo=$DefaultRepo
     tag=$1


### PR DESCRIPTION
Old function.sh could not handle ICP-versions 3.x. Tag could not be set when uploading own .tar.gz ball with ICP installation files. 